### PR TITLE
add the entra auth service

### DIFF
--- a/src/app/auth_services/EntraAuthService.py
+++ b/src/app/auth_services/EntraAuthService.py
@@ -4,7 +4,8 @@ from .AuthServiceBase import AuthService
 from . import logger
 
 
-class KeycloakAuthService(AuthService):
+class EntraAuthService(AuthService):
+
     def get_oidc_config(self):
         return {
             'OIDC_ID_TOKEN_COOKIE_SECURE': False,


### PR DESCRIPTION
It appears that when it comes to connecting it has similar urls that we would get once we set up the app within the Azure Portal to  allow connections to Entra, so we cannot do much else at this time. Once we have an Entra we can connect to we can make sure this works.